### PR TITLE
Reconcile joint fitting APIs for v0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.0 - Unreleased
+
+### Added
+
+- Added generalized joint fitting support for fixed initial times, parameterized `u0_builder` initial states, observable callbacks, trajectory-specific residual scaling, raw/scaled SSE reporting, bounded Nelder-Mead screening, multistart fitting, and one- or two-sided bound profiling.
+- Added reusable joint BIC, pooling BIC, and parameter-stability summary helpers for downstream model reconciliation workflows.
+
+### Fixed
+
+- Corrected joint BIC parameter counting to use the optimized parameter vector length while excluding fixed initial-time seeding states and observations not present in `dataset_specs`.
+- Rejected failed, non-finite, negative-prediction, and failure-sentinel joint fits consistently during joint optimization and multistart ranking.
+
 ## v0.3.0 - 2026-04-09
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## v0.4.0 - Unreleased
+## v0.4.1 - 2026-08-11
+
+### Breaking changes
+
+- Breaking: this is a pre-1.0 minor release line, so `v0.4.x` is treated as a breaking update relative to `v0.3.x` for Julia package registration and downstream compatibility expectations.
+- Breaking: joint fitting now rejects failed, non-finite, negative-prediction, and failure-sentinel fits consistently during optimization and multistart ranking. Downstream validation scripts that asserted legacy finite-fit counts may need a scientific review of the new ranked model set.
+- Breaking: joint BIC summaries now count optimized joint parameters directly and exclude fixed initial-time seeding states and observations absent from `dataset_specs`, which can change model ranking summaries compared with earlier downstream helper implementations.
 
 ### Added
 
@@ -13,6 +19,12 @@ All notable changes to this project will be documented in this file.
 
 - Corrected joint BIC parameter counting to use the optimized parameter vector length while excluding fixed initial-time seeding states and observations not present in `dataset_specs`.
 - Rejected failed, non-finite, negative-prediction, and failure-sentinel joint fits consistently during joint optimization and multistart ranking.
+
+## v0.4.0 - 2026-08-11
+
+### Notes
+
+- Superseded by `v0.4.1` before Julia General Registry registration to add registry-compatible standard-library compat bounds and explicit breaking-change release notes.
 
 ## v0.3.0 - 2026-04-09
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GrowthParameterEstimation"
 uuid = "f2d48b76-d258-4732-aa20-f5a609aab424"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Kadin"]
 
 [deps]
@@ -29,6 +29,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 BlackBoxOptim = "0.6"
 CSV = "0.10"
 DataFrames = "1"
+Dates = "1"
 DiffEqParamEstim = "2"
 DifferentialEquations = "7"
 Distributions = "0.25"
@@ -40,8 +41,11 @@ OptimizationBBO = "0.1"
 OptimizationOptimJL = "0.1"
 OrdinaryDiffEq = "6.70"
 Plots = "1"
+Random = "1"
 RecursiveArrayTools = "3"
+Statistics = "1"
 StatsBase = "0.33, 0.34"
+TOML = "1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GrowthParameterEstimation"
 uuid = "f2d48b76-d258-4732-aa20-f5a609aab424"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kadin"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The package exports many symbols, but most users should focus on the entry point
 | Enforce richer metadata for pipelines | `validate_required_metadata`, `validate_strict_schema` | Useful before staged or production workflows |
 | Fit one model to one dataset | `run_single_fit` | Smallest fitting API |
 | Compare candidate models | `compare_models`, `compare_models_dict`, `rank_models` | `rank_models` is the workflow-oriented option |
-| Fit across related datasets jointly | `run_joint_fit`, `compare_joint_models_dict` | For shared-parameter multi-state or multi-dataset fits |
+| Fit across related datasets jointly | `run_joint_fit`, `run_joint_multistart`, `profile_joint_fit_bounds`, `compare_joint_models_dict` | For shared-parameter multi-state or multi-dataset fits |
 | Run a standard pipeline | `default_config`, `build_conditions`, `run_pipeline` | Best default for end-to-end analysis |
 | Run a staged pipeline | `PipelineStage`, `default_stages`, `run_staged_pipeline` | Best for inherited-parameter multi-stage workflows |
 | Export workflow artifacts | `plot_topk`, `export_results`, `save_run_manifest`, `load_run_manifest` | Produces tables, diagnostics, figures, and resume state |
@@ -309,7 +309,21 @@ fit = run_joint_fit(logistic_joint!, datasets, [1.0, 2.0], [0.2, 20.0];
 
 @show fit.params
 @show fit.bic
+@show fit.raw_sse fit.scaled_sse
 ```
+
+Joint dataset specs may use `residual_scale` to scale each trajectory's
+residuals and may provide `observable = (u, p, t) -> ...` instead of
+`state_index`. Use `initial_time` when the initial state precedes the first
+observation, and `u0_builder = p -> ...` when fitted parameters determine the
+initial state. `run_joint_multistart` ranks finite fits across starts, while
+`profile_joint_fit_bounds` and `profile_joint_fit_bounds_two_sided` test whether
+near-bound estimates justify expanded optimization bounds.
+
+For pooled downstream analyses, `summarize_joint_bic`,
+`summarize_joint_bic_by_group`, `summarize_pooling_bic`, and
+`summarize_joint_parameter_stability` provide reusable BIC and parameter
+stability summaries without embedding project-specific biology.
 
 ### Compare two models
 ```julia
@@ -350,7 +364,7 @@ bic, ssr = calculate_bic(prob, x, y, Tsit5(), [0.1, 5.0])
 - `Models.to_ode!(Models.build_exponential_with_death_and_delay())(du,u,p,t)` # p = [r, K, death_rate, t_lag]
 
 ## Key exported helpers (in `GrowthParameterEstimation`)
-- Fitting: `run_single_fit`, `compare_models`, `compare_datasets`, `compare_models_dict`, `fit_three_datasets`, `run_joint_fit`, `compare_joint_models_dict`, `calculate_bic`.
+- Fitting: `run_single_fit`, `compare_models`, `compare_datasets`, `compare_models_dict`, `fit_three_datasets`, `run_joint_fit`, `run_joint_multistart`, `profile_joint_fit_bounds`, `profile_joint_fit_bounds_two_sided`, `compare_joint_models_dict`, `calculate_bic`.
 - Analysis: `leave_one_out_validation`, `k_fold_cross_validation`, `parameter_sensitivity_analysis`, `residual_analysis`, `enhanced_bic_analysis`.
 - Workflow/core pipeline: `run_pipeline`, `run_staged_pipeline`, `default_stages`, `default_population_stages`, `default_population_cellline_stages`, `summarize_datasets`.
 - Hardening: `validate_required_metadata`, `validate_strict_schema`, `generate_qc_report`, `save_qc_report`, `save_run_manifest`, `load_run_manifest`, `bootstrap_stage_uncertainty`.

--- a/docs/AI Reference.md
+++ b/docs/AI Reference.md
@@ -249,26 +249,45 @@ where \(k\) is number of fitted parameters.
 s_j = \sqrt{\frac{1}{M-1}\sum_{m=1}^M (p_{m,j}-\bar p_j)^2}.
 \]
 
-### `run_joint_fit(model, dataset_specs, u0, p0; solver, bounds, show_stats, maxiters)`
+### `run_joint_fit(model, dataset_specs, u0, p0; solver, bounds, u0_builder, initial_time, optimizer, show_stats, maxiters)`
 **English:** Fits one shared parameter vector across multiple observed datasets/states in a multi-state ODE.
 
-Each dataset spec contains `(x, y, state_index)`.
+Each dataset spec contains `(x, y, state_index)` or `(x, y, observable)`.
+Optional `residual_scale` applies fixed trajectory-specific residual scaling.
+`initial_time` supports seeded initial states before the first observation, and
+`u0_builder` supports parameterized initial states.
 
 **Math:** Uses a joint objective:
 \[
 \min_p \sum_{d=1}^{D}\sum_{i=1}^{n_d}\left(y_{d,i}-\hat y_{d,i}(p)\right)^2,
 \]
 where \(\hat y_{d,i}(p)\) comes from the state component indexed by `state_index`.
+The reported `sse` is scaled SSE; `raw_sse` keeps the unscaled residual sum.
 
 Reports joint BIC:
 \[
 \mathrm{BIC}_{joint}=n_{tot}\log\left(\frac{\mathrm{SSE}_{joint}}{n_{tot}}\right)+k\log(n_{tot}).
 \]
 
+### `run_joint_multistart(model, dataset_specs, u0, starts; kwargs...)`
+**English:** Runs `run_joint_fit` from multiple starts and returns the finite fit
+with the lowest BIC plus a per-start summary table. Failed, non-finite, and
+failure-sentinel fits are excluded from best-fit selection.
+
+### `profile_joint_fit_bounds` / `profile_joint_fit_bounds_two_sided`
+**English:** Refit near-bound joint estimates under expanded candidate bounds and
+accept expansions only when BIC improves and the estimate moves away from the
+new bound. The two-sided variant also supports explicit lower-bound profiles.
+
 ### `compare_joint_models_dict(dataset_specs, u0, specs; default_solver, show_stats, output_csv)`
 **English:** Batch-fits several joint models and writes a BIC/SSE summary CSV.
 
 **Math:** Applies the same joint objective for each model and ranks by lower joint BIC.
+
+### `summarize_joint_bic`, `summarize_pooling_bic`, `summarize_joint_parameter_stability`
+**English:** Summarize BIC across environments, flag inadequate pooling when
+independent diagnostic fits materially outperform eligible shared/partial
+pooling, and classify cross-environment parameter stability.
 
 ---
 

--- a/docs/src/tutorial/advanced_usage.md
+++ b/docs/src/tutorial/advanced_usage.md
@@ -180,7 +180,16 @@ joint_result = run_joint_fit(
 println("Joint fitting results:")
 println("Parameters: $(joint_result.params)")
 println("BIC: $(joint_result.bic)")
+println("Raw SSE: $(joint_result.raw_sse)")
+println("Scaled SSE: $(joint_result.scaled_sse)")
 ```
+
+Use `residual_scale` in each dataset spec to compare trajectories on fixed
+scales, `initial_time` when the initial state is seeded before the first
+observation, and `u0_builder = p -> ...` when parameters determine the initial
+state. For difficult surfaces, run several starts with `run_joint_multistart`
+and profile near-bound estimates with `profile_joint_fit_bounds` or
+`profile_joint_fit_bounds_two_sided`.
 
 ## Resuming Long-Running Workflows
 

--- a/src/GrowthParameterEstimation.jl
+++ b/src/GrowthParameterEstimation.jl
@@ -8,6 +8,7 @@ include("registry.jl")
 include("simulation.jl")
 include("observation.jl")
 include("fitting.jl")
+include("joint_summary.jl")
 include("analysis.jl")
 include("workflow.jl")
 # include("models_legacy.jl")  # Remove legacy ODE RHS functions for backward compatibility
@@ -19,6 +20,7 @@ using .Registry
 using .Simulation
 using .Observation
 using .Fitting
+using .JointSummary
 using .Analysis
 using .Workflow
 
@@ -49,7 +51,10 @@ export
     # Fitting functions
     setUpProblem, calculate_bic, pQuickStat, run_single_fit,
     compare_models, compare_datasets, compare_models_dict, fit_three_datasets, fit_model, fit_condition,
-    run_joint_fit, compare_joint_models_dict,
+    run_joint_fit, run_joint_multistart, profile_joint_fit_bounds,
+    profile_joint_fit_bounds_two_sided, compare_joint_models_dict,
+    summarize_joint_bic, summarize_joint_bic_by_group, summarize_joint_parameter_stability,
+    summarize_pooling_bic, symmetric_relative_pair,
 
     # Analysis functions
     leave_one_out_validation, k_fold_cross_validation, parameter_sensitivity_analysis,

--- a/src/data.jl
+++ b/src/data.jl
@@ -6,6 +6,7 @@ using DataFrames
 using Dates
 
 export
+    REQUIRED_COLUMNS,
     normalize_schema,
     validate_timeseries,
     validate_required_metadata,
@@ -19,6 +20,7 @@ Metadata fields that are strictly required for processing.
 These must be present in the normalized schema for strict validation to pass.
 """
 const STRICT_REQUIRED_METADATA = [:time, :count, :error, :dose, :cell_line, :density, :replicate]
+const REQUIRED_COLUMNS = [:time, :count, :error, :dose, :treatment_amount, :cell_line, :density, :replicate]
 
 """
     normalize_schema(df::DataFrame) -> DataFrame
@@ -66,6 +68,9 @@ function normalize_schema(df::DataFrame)
         "concentration" => :dose,
         "Concentration" => :dose,
         "CONCENTRATION" => :dose,
+        "TreatmentAmount" => :treatment_amount,
+        "treatment_amount" => :treatment_amount,
+        "TREATMENT_AMOUNT" => :treatment_amount,
         "cell_line" => :cell_line,
         "CellLine" => :cell_line,
         "CELL_LINE" => :cell_line,
@@ -90,11 +95,17 @@ function normalize_schema(df::DataFrame)
         end
     end
     
+    if :dose in Symbol.(names(normalized)) && !(:treatment_amount in Symbol.(names(normalized)))
+        normalized[!, :treatment_amount] = copy(normalized[!, :dose])
+    elseif :treatment_amount in Symbol.(names(normalized)) && !(:dose in Symbol.(names(normalized)))
+        normalized[!, :dose] = copy(normalized[!, :treatment_amount])
+    end
+
     # Ensure required columns exist, add missing ones with defaults
-    required_cols = [:time, :count, :error, :dose, :cell_line, :density, :replicate]
+    required_cols = REQUIRED_COLUMNS
     for col in required_cols
         if !(col in Symbol.(names(normalized)))
-            if col == :time || col == :count || col == :error || col == :dose || col == :density
+            if col == :time || col == :count || col == :error || col == :dose || col == :treatment_amount || col == :density
                 normalized[!, col] = fill(0.0, nrow(normalized))
             elseif col == :cell_line
                 normalized[!, col] = fill("unknown", nrow(normalized))
@@ -109,6 +120,7 @@ function normalize_schema(df::DataFrame)
     normalized.count = Float64.(normalized.count)
     normalized.error = Float64.(normalized.error)
     normalized.dose = Float64.(normalized.dose)
+    normalized.treatment_amount = Float64.(normalized.treatment_amount)
     normalized.cell_line = String.(normalized.cell_line)
     normalized.density = Float64.(normalized.density)
     normalized.replicate = Int.(normalized.replicate)
@@ -135,11 +147,13 @@ Checks for monotonic time, non-negative counts, and positive errors.
 - `ErrorException` if validation fails
 """
 function validate_timeseries(df::DataFrame)
-    # Check for monotonic time within each condition
-    # For simplicity, we'll check overall monotonicity
-    # In a more sophisticated implementation, we'd group by condition first
-    if !all(diff(df.time) .>= 0)
-        throw(ErrorException("Time values are not monotonic increasing"))
+    # Check for monotonic time within each observed trajectory/condition.
+    grouping_cols = [col for col in [:cell_line, :density, :dose, :replicate] if col in Symbol.(names(df))]
+    groups = isempty(grouping_cols) ? [df] : groupby(df, grouping_cols)
+    for group in groups
+        if !all(diff(group.time) .>= 0)
+            throw(ErrorException("Time values are not monotonic increasing within a condition"))
+        end
     end
     
     # Check for non-negative counts

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -1,4 +1,4 @@
-﻿# Fitting module - Contains all ODE fitting and comparison functions
+# Fitting module - Contains all ODE fitting and comparison functions
 module Fitting
 
 using StatsBase
@@ -18,7 +18,9 @@ using ..Registry
 
 export setUpProblem, calculate_bic, pQuickStat, run_single_fit,
     compare_models, compare_datasets, compare_models_dict, fit_three_datasets,
-    run_joint_fit, compare_joint_models_dict, fit_model, fit_condition, predict_model
+    run_joint_fit, run_joint_multistart, profile_joint_fit_bounds,
+    profile_joint_fit_bounds_two_sided, compare_joint_models_dict,
+    fit_model, fit_condition, predict_model
 
 """
     setUpProblem(model, x, y, solver, u0, p0, tspan, bounds; max_time=100.0, maxiters=10_000)
@@ -236,6 +238,10 @@ function run_single_fit(
     max_time::Real   = 100.0,
     show_stats::Bool = true,
 )
+    if model isa Models.AbstractBaseModel || model isa Models.CompositeModel
+        model = Models.to_ode!(model)
+    end
+
     # Handle fixed parameters by wrapping the model
     if fixed_params !== nothing
         original_model = model
@@ -1106,14 +1112,28 @@ function fit_three_datasets(
 end
 
 """
-    run_joint_fit(model, dataset_specs, u0, p0; solver=Tsit5(), bounds=nothing, show_stats=false, maxiters=10_000)
+    run_joint_fit(model, dataset_specs, u0, p0; solver=Tsit5(), bounds=nothing,
+                  u0_builder=nothing, initial_time=nothing, show_stats=false,
+                  maxiters=10_000)
 
 Fit a single parameter vector `p` for a multi-state ODE model against multiple datasets.
 
 `dataset_specs` is a vector of NamedTuples with fields:
 - `x`: observation times
 - `y`: observations
-- `state_index`: 1-based state index in solution vector
+- either `state_index`: 1-based state index in the solution vector
+- or `observable`: a function accepting `(u, p, t)`, `(u, p)`, or `u`
+- optional `residual_scale`: a positive fixed scale applied to residuals for that
+  dataset. The default `1.0` preserves ordinary SSE.
+
+`u0_builder`, when supplied, maps the parameter vector to the initial state. This supports
+joint mixture models whose fitted parameters include an initial population fraction.
+`initial_time` sets the time associated with `u0` when it precedes the first
+observation. This permits day-zero seeding states without adding synthetic
+observations to the likelihood or BIC sample size.
+`reltol` and `abstol` control ODE solve accuracy during optimization and prediction.
+Set `optimizer=:nelder_mead` for bounded derivative-free screening of nonsmooth or
+stiff models; the default remains `:bfgs` for backward compatibility.
 
 Returns `(params, bic, sse, solution, predictions, save_times)`.
 """
@@ -1124,8 +1144,13 @@ function run_joint_fit(
     p0::Vector{<:Real};
     solver            = Tsit5(),
     bounds            = nothing,
+    u0_builder        = nothing,
+    initial_time      = nothing,
     show_stats::Bool  = false,
     maxiters::Integer = 10_000,
+    reltol::Real      = 1e-10,
+    abstol::Real      = 1e-10,
+    optimizer::Symbol = :bfgs,
 )
     isempty(dataset_specs) && throw(ArgumentError("dataset_specs cannot be empty"))
 
@@ -1133,38 +1158,65 @@ function run_joint_fit(
         (
             x = Float64.(collect(ds.x)),
             y = Float64.(collect(ds.y)),
-            state_index = Int(ds.state_index),
+            state_index = haskey(ds, :state_index) ? Int(ds.state_index) : 0,
+            observable = haskey(ds, :observable) ? ds.observable : nothing,
+            residual_scale = haskey(ds, :residual_scale) ? max(Float64(ds.residual_scale), eps(Float64)) : 1.0,
         ) for ds in dataset_specs
     ]
 
     n_states = length(u0)
     for ds in processed
-        ds.state_index >= 1 || throw(ArgumentError("state_index must be >= 1"))
-        ds.state_index <= n_states || throw(ArgumentError("state_index $(ds.state_index) exceeds u0 length $n_states"))
+        if ds.observable === nothing
+            ds.state_index >= 1 || throw(ArgumentError("each dataset requires state_index >= 1 or an observable"))
+            ds.state_index <= n_states || throw(ArgumentError("state_index $(ds.state_index) exceeds u0 length $n_states"))
+        end
         length(ds.x) == length(ds.y) || throw(ArgumentError("x and y length mismatch in dataset_specs"))
     end
 
+    initial_state(p) = begin
+        values = u0_builder === nothing ? u0 : u0_builder(p)
+        length(values) == n_states || throw(ArgumentError("u0_builder must return $n_states states"))
+        collect(values)
+    end
+
+    joint_observable(ds, state, p, t) = begin
+        ds.observable === nothing && return state[ds.state_index]
+        if applicable(ds.observable, state, p, t)
+            return ds.observable(state, p, t)
+        elseif applicable(ds.observable, state, p)
+            return ds.observable(state, p)
+        elseif applicable(ds.observable, state)
+            return ds.observable(state)
+        end
+        throw(ArgumentError("observable must accept (u, p, t), (u, p), or u"))
+    end
+
     save_times = sort(unique(vcat([ds.x for ds in processed]...)))
-    tspan = (save_times[1], save_times[end])
-    prob = ODEProblem(model, Float64.(u0), tspan, Float64.(p0))
+    fit_initial_time = initial_time === nothing ? save_times[1] : Float64(initial_time)
+    fit_initial_time <= save_times[1] ||
+        throw(ArgumentError("initial_time must be no later than the first observation"))
+    tspan = (fit_initial_time, save_times[end])
+    prob = ODEProblem(model, Float64.(initial_state(p0)), tspan, Float64.(p0))
 
     function objective(p)
-        sol = solve(remake(prob; p = p), solver; saveat = save_times, reltol = 1e-10, abstol = 1e-10)
-        if sol.retcode != ReturnCode.Success
+        sol = try
+            solve(remake(prob; p = p, u0 = initial_state(p)), solver; saveat = save_times, reltol = reltol, abstol = abstol)
+        catch
             return 1e12
         end
+        sol.retcode == ReturnCode.Success || return 1e12
 
         sse = 0.0
         for ds in processed
             for (xi, yi) in zip(ds.x, ds.y)
                 idx = findfirst(t -> isapprox(t, xi; atol = 1e-10, rtol = 1e-10), save_times)
                 idx === nothing && return 1e12
-                yhat = sol.u[idx][ds.state_index]
-                isfinite(yhat) || return 1e12
-                sse += (yi - yhat)^2
+                yhat = joint_observable(ds, sol.u[idx], p, xi)
+                isfinite(yhat) && yhat >= 0 || return 1e12
+                sse += ((yi - yhat) / ds.residual_scale)^2
             end
         end
-        return sse
+        return isfinite(sse) ? sse : 1e12
     end
 
     nparams = length(p0)
@@ -1182,23 +1234,39 @@ function run_joint_fit(
         ]
     end
 
-    loss = Optimization.OptimizationFunction((x, _) -> objective(x), Optimization.AutoForwardDiff())
     lb = Float64[first(b) for b in bounds]
     ub = Float64[last(b) for b in bounds]
-    optprob = Optimization.OptimizationProblem(loss, Float64.(p0); lb = lb, ub = ub)
-    result = Optimization.solve(optprob, OptimizationOptimJL.Fminbox(OptimizationOptimJL.BFGS()); maxiters = maxiters)
-
-    p_opt = collect(result.u)
+    p_opt = if optimizer == :bfgs
+        loss = Optimization.OptimizationFunction((x, _) -> objective(x), Optimization.AutoForwardDiff())
+        optprob = Optimization.OptimizationProblem(loss, Float64.(p0); lb = lb, ub = ub)
+        result = Optimization.solve(optprob, OptimizationOptimJL.Fminbox(OptimizationOptimJL.BFGS()); maxiters = maxiters)
+        collect(result.u)
+    elseif optimizer == :nelder_mead
+        bounded(z) = lb .+ (ub .- lb) ./ (1 .+ exp.(-clamp.(z, -30.0, 30.0)))
+        fractions = clamp.((Float64.(p0) .- lb) ./ (ub .- lb), 1e-6, 1 - 1e-6)
+        z0 = log.(fractions ./ (1 .- fractions))
+        loss = Optimization.OptimizationFunction((z, _) -> objective(bounded(z)))
+        optprob = Optimization.OptimizationProblem(loss, z0)
+        result = Optimization.solve(optprob, OptimizationOptimJL.NelderMead(); maxiters = maxiters)
+        collect(bounded(result.u))
+    else
+        throw(ArgumentError("optimizer must be :bfgs or :nelder_mead"))
+    end
     sse = objective(p_opt)
     n = sum(length(ds.x) for ds in processed)
     k = length(p_opt)
     bic = n * log(max(sse, 1e-12) / n) + k * log(n)
 
-    sol_opt = solve(remake(prob; p = p_opt), solver; saveat = save_times, reltol = 1e-10, abstol = 1e-10)
+    sol_opt = solve(remake(prob; p = p_opt, u0 = initial_state(p_opt)), solver; saveat = save_times, reltol = reltol, abstol = abstol)
     predictions = [
-        [sol_opt.u[findfirst(t -> isapprox(t, xi; atol = 1e-10, rtol = 1e-10), save_times)][ds.state_index] for xi in ds.x]
+        [joint_observable(ds, sol_opt.u[findfirst(t -> isapprox(t, xi; atol = 1e-10, rtol = 1e-10), save_times)], p_opt, xi)
+         for xi in ds.x]
         for ds in processed
     ]
+    raw_sse = sum(
+        sum((yi - yhat)^2 for (yi, yhat) in zip(ds.y, prediction))
+        for (ds, prediction) in zip(processed, predictions)
+    )
 
     if show_stats
         println("Optimized params: ", p_opt)
@@ -1210,9 +1278,333 @@ function run_joint_fit(
         params = p_opt,
         bic = bic,
         sse = sse,
+        scaled_sse = sse,
+        raw_sse = raw_sse,
         solution = sol_opt,
         predictions = predictions,
         save_times = save_times,
+        initial_time = fit_initial_time,
+    )
+end
+
+"""
+    run_joint_multistart(model, dataset_specs, u0, starts; kwargs...)
+
+Run `run_joint_fit` from several initial parameter vectors and retain the
+finite fit with the lowest BIC. All starts must have the same parameter count.
+The returned `summary` records successful and failed starts for auditability.
+"""
+function run_joint_multistart(
+    model::Function,
+    dataset_specs::Vector{<:NamedTuple},
+    u0::Vector{<:Real},
+    starts::Vector{<:AbstractVector};
+    kwargs...,
+)
+    isempty(starts) && throw(ArgumentError("starts cannot be empty"))
+    parameter_count = length(first(starts))
+    all(length(start) == parameter_count for start in starts) ||
+        throw(ArgumentError("all multistart vectors must have equal length"))
+
+    fits = Any[]
+    successful_indices = Int[]
+    rows = NamedTuple[]
+    for (start_index, start) in enumerate(starts)
+        fit = try
+            run_joint_fit(model, dataset_specs, u0, Float64.(start); kwargs...)
+        catch error
+            push!(fits, nothing)
+            push!(rows, (
+                start_index = start_index,
+                status = "failed",
+                bic = NaN,
+                scaled_sse = NaN,
+                raw_sse = NaN,
+                params = "",
+                message = sprint(showerror, error),
+            ))
+            continue
+        end
+        valid = isfinite(fit.bic) && isfinite(fit.scaled_sse) &&
+            isfinite(fit.raw_sse) && fit.scaled_sse < 9.99e11
+        push!(fits, fit)
+        valid && push!(successful_indices, start_index)
+        push!(rows, (
+            start_index = start_index,
+            status = valid ? "completed" : "invalid",
+            bic = valid ? Float64(fit.bic) : NaN,
+            scaled_sse = valid ? Float64(fit.scaled_sse) : NaN,
+            raw_sse = valid ? Float64(fit.raw_sse) : NaN,
+            params = valid ? string(Float64.(fit.params)) : "",
+            message = valid ? "" : "Non-finite or failure-sentinel joint fit.",
+        ))
+    end
+    isempty(successful_indices) && error("No finite multistart fit completed")
+    best_start_index = successful_indices[
+        argmin([Float64(fits[index].bic) for index in successful_indices])
+    ]
+    return (
+        fit = fits[best_start_index],
+        fits = fits,
+        summary = DataFrame(rows),
+        best_start_index = best_start_index,
+    )
+end
+
+"""
+    profile_joint_fit_bounds(model, dataset_specs, u0, p0;
+        bounds, parameter_names, explicit_upper_profiles=Dict(),
+        trigger_fraction=0.02, expansion_factors=[1.5, 2.0],
+        min_bic_improvement=2.0, min_new_bound_margin=0.05, kwargs...)
+
+Run a joint fit and sequentially profile upper bounds for parameters whose
+estimate lies within `trigger_fraction` of the active bound. An expanded fit is
+accepted only when it improves BIC by at least `min_bic_improvement` and moves
+the estimate at least `min_new_bound_margin` inside the expanded interval.
+
+Returns `(fit, bounds, profile, identifiability)`. `profile` records every
+attempt, and `identifiability` marks parameters that remain near a bound.
+"""
+function profile_joint_fit_bounds(
+    model::Function,
+    dataset_specs::Vector{<:NamedTuple},
+    u0::Vector{<:Real},
+    p0::Vector{<:Real};
+    bounds::Vector{<:Tuple},
+    parameter_names::Vector{Symbol},
+    explicit_upper_profiles::AbstractDict = Dict{Symbol,Vector{Float64}}(),
+    profile_parameters::Union{Nothing,Vector{Symbol}} = nothing,
+    trigger_fraction::Real = 0.02,
+    expansion_factors::Vector{Float64} = [1.5, 2.0],
+    min_bic_improvement::Real = 2.0,
+    min_new_bound_margin::Real = 0.05,
+    kwargs...,
+)
+    length(bounds) == length(p0) == length(parameter_names) ||
+        throw(ArgumentError("bounds, p0, and parameter_names must have equal length"))
+    0 <= trigger_fraction < 1 || throw(ArgumentError("trigger_fraction must be in [0, 1)"))
+    0 <= min_new_bound_margin < 1 || throw(ArgumentError("min_new_bound_margin must be in [0, 1)"))
+
+    active_bounds = [(Float64(lo), Float64(hi)) for (lo, hi) in bounds]
+    best = run_joint_fit(model, dataset_specs, u0, Float64.(p0); bounds = active_bounds, kwargs...)
+    rows = NamedTuple[]
+
+    for index in eachindex(parameter_names)
+        name = parameter_names[index]
+        profile_parameters !== nothing && !(name in profile_parameters) && continue
+        lower, upper = active_bounds[index]
+        span = upper - lower
+        span > 0 || continue
+        base_margin = (upper - Float64(best.params[index])) / span
+        base_margin <= trigger_fraction || continue
+
+        candidates = haskey(explicit_upper_profiles, name) ?
+            sort(unique(Float64.(explicit_upper_profiles[name]))) :
+            sort(unique(upper .* expansion_factors))
+        candidates = filter(>(upper), candidates)
+
+        accepted = false
+        for candidate_upper in candidates
+            candidate_bounds = copy(active_bounds)
+            candidate_bounds[index] = (lower, candidate_upper)
+            candidate_p0 = clamp.(Float64.(best.params), first.(candidate_bounds), last.(candidate_bounds))
+            candidate = run_joint_fit(
+                model,
+                dataset_specs,
+                u0,
+                candidate_p0;
+                bounds = candidate_bounds,
+                kwargs...,
+            )
+            candidate_span = candidate_upper - lower
+            candidate_margin = (candidate_upper - Float64(candidate.params[index])) / candidate_span
+            bic_improvement = Float64(best.bic) - Float64(candidate.bic)
+            accept = bic_improvement >= min_bic_improvement && candidate_margin >= min_new_bound_margin
+            push!(rows, (
+                parameter = String(name),
+                original_upper = upper,
+                candidate_upper = candidate_upper,
+                original_bic = Float64(best.bic),
+                candidate_bic = Float64(candidate.bic),
+                bic_improvement = bic_improvement,
+                estimate = Float64(candidate.params[index]),
+                upper_margin_fraction = candidate_margin,
+                accepted = accept,
+            ))
+            if accept
+                best = candidate
+                active_bounds = candidate_bounds
+                accepted = true
+                break
+            end
+        end
+
+        if !accepted && isempty(candidates)
+            push!(rows, (
+                parameter = String(name),
+                original_upper = upper,
+                candidate_upper = upper,
+                original_bic = Float64(best.bic),
+                candidate_bic = Float64(best.bic),
+                bic_improvement = 0.0,
+                estimate = Float64(best.params[index]),
+                upper_margin_fraction = base_margin,
+                accepted = false,
+            ))
+        end
+    end
+
+    identifiability = DataFrame(
+        parameter = String.(parameter_names),
+        estimate = Float64.(best.params),
+        lower_bound = first.(active_bounds),
+        upper_bound = last.(active_bounds),
+    )
+    identifiability.bound_position = [
+        (identifiability.estimate[i] - identifiability.lower_bound[i]) /
+        max(identifiability.upper_bound[i] - identifiability.lower_bound[i], eps(Float64))
+        for i in 1:nrow(identifiability)
+    ]
+    identifiability.identifiability = [
+        position <= trigger_fraction || position >= 1 - trigger_fraction ?
+            "poorly_identified_at_bound" : "interior"
+        for position in identifiability.bound_position
+    ]
+
+    return (
+        fit = best,
+        bounds = active_bounds,
+        profile = DataFrame(rows),
+        identifiability = identifiability,
+    )
+end
+
+"""
+    profile_joint_fit_bounds_two_sided(model, dataset_specs, u0, p0;
+        bounds, parameter_names, explicit_lower_profiles=Dict(), kwargs...)
+
+Run the standard upper-bound profile and then test explicitly supplied lower
+bounds. Lower expansion is deliberately explicit because many biological
+parameters have a physical lower limit of zero. A candidate is accepted only
+when it improves BIC and moves the estimate away from the expanded boundary.
+"""
+function profile_joint_fit_bounds_two_sided(
+    model::Function,
+    dataset_specs::Vector{<:NamedTuple},
+    u0::Vector{<:Real},
+    p0::Vector{<:Real};
+    bounds::Vector{<:Tuple},
+    parameter_names::Vector{Symbol},
+    explicit_upper_profiles::AbstractDict = Dict{Symbol,Vector{Float64}}(),
+    explicit_lower_profiles::AbstractDict = Dict{Symbol,Vector{Float64}}(),
+    physical_lower_limits::AbstractDict = Dict{Symbol,Float64}(),
+    profile_parameters::Union{Nothing,Vector{Symbol}} = nothing,
+    trigger_fraction::Real = 0.02,
+    min_bic_improvement::Real = 2.0,
+    min_new_bound_margin::Real = 0.05,
+    kwargs...,
+)
+    upper = profile_joint_fit_bounds(
+        model,
+        dataset_specs,
+        u0,
+        p0;
+        bounds = bounds,
+        parameter_names = parameter_names,
+        explicit_upper_profiles = explicit_upper_profiles,
+        profile_parameters = profile_parameters,
+        trigger_fraction = trigger_fraction,
+        min_bic_improvement = min_bic_improvement,
+        min_new_bound_margin = min_new_bound_margin,
+        kwargs...,
+    )
+    best = upper.fit
+    active_bounds = copy(upper.bounds)
+    rows = NamedTuple[]
+    for row in eachrow(upper.profile)
+        push!(rows, (
+            parameter = String(row.parameter),
+            direction = "upper",
+            original_bound = Float64(row.original_upper),
+            candidate_bound = Float64(row.candidate_upper),
+            original_bic = Float64(row.original_bic),
+            candidate_bic = Float64(row.candidate_bic),
+            bic_improvement = Float64(row.bic_improvement),
+            estimate = Float64(row.estimate),
+            bound_margin_fraction = Float64(row.upper_margin_fraction),
+            accepted = Bool(row.accepted),
+        ))
+    end
+
+    for index in eachindex(parameter_names)
+        name = parameter_names[index]
+        profile_parameters !== nothing && !(name in profile_parameters) && continue
+        haskey(explicit_lower_profiles, name) || continue
+        lower, upper_bound = active_bounds[index]
+        span = upper_bound - lower
+        span > 0 || continue
+        lower_margin = (Float64(best.params[index]) - lower) / span
+        lower_margin <= trigger_fraction || continue
+        physical_lower = Float64(get(physical_lower_limits, name, -Inf))
+        candidates = sort(unique(Float64.(explicit_lower_profiles[name])); rev = true)
+        candidates = filter(candidate -> physical_lower <= candidate < lower, candidates)
+        for candidate_lower in candidates
+            candidate_bounds = copy(active_bounds)
+            candidate_bounds[index] = (candidate_lower, upper_bound)
+            candidate_p0 = clamp.(Float64.(best.params), first.(candidate_bounds), last.(candidate_bounds))
+            candidate = run_joint_fit(
+                model,
+                dataset_specs,
+                u0,
+                candidate_p0;
+                bounds = candidate_bounds,
+                kwargs...,
+            )
+            candidate_span = upper_bound - candidate_lower
+            candidate_margin = (Float64(candidate.params[index]) - candidate_lower) / candidate_span
+            bic_improvement = Float64(best.bic) - Float64(candidate.bic)
+            accept = bic_improvement >= min_bic_improvement && candidate_margin >= min_new_bound_margin
+            push!(rows, (
+                parameter = String(name),
+                direction = "lower",
+                original_bound = lower,
+                candidate_bound = candidate_lower,
+                original_bic = Float64(best.bic),
+                candidate_bic = Float64(candidate.bic),
+                bic_improvement = bic_improvement,
+                estimate = Float64(candidate.params[index]),
+                bound_margin_fraction = candidate_margin,
+                accepted = accept,
+            ))
+            if accept
+                best = candidate
+                active_bounds = candidate_bounds
+                break
+            end
+        end
+    end
+
+    identifiability = DataFrame(
+        parameter = String.(parameter_names),
+        estimate = Float64.(best.params),
+        lower_bound = first.(active_bounds),
+        upper_bound = last.(active_bounds),
+    )
+    identifiability.bound_position = [
+        (identifiability.estimate[i] - identifiability.lower_bound[i]) /
+        max(identifiability.upper_bound[i] - identifiability.lower_bound[i], eps(Float64))
+        for i in 1:nrow(identifiability)
+    ]
+    identifiability.identifiability = [
+        position <= trigger_fraction || position >= 1 - trigger_fraction ?
+            "poorly_identified_at_bound" : "interior"
+        for position in identifiability.bound_position
+    ]
+    return (
+        fit = best,
+        bounds = active_bounds,
+        profile = DataFrame(rows),
+        identifiability = identifiability,
     )
 end
 
@@ -1222,6 +1614,7 @@ end
 Fit multiple joint models and write a BIC/SSE summary CSV.
 
 `specs` maps model names to NamedTuples like `(model=<f!>, p0=<vector>, bounds=<vector>)`.
+A spec may also override `u0` or provide `u0_builder` for parameterized initial states.
 """
 function compare_joint_models_dict(
     dataset_specs::Vector{<:NamedTuple},
@@ -1229,21 +1622,26 @@ function compare_joint_models_dict(
     specs::Dict{String,<:NamedTuple};
     default_solver      = Tsit5(),
     show_stats::Bool    = false,
-    output_csv::String  = "joint_model_comparison.csv",
+    output_csv::Union{Nothing,String} = "joint_model_comparison.csv",
+    maxiters::Integer = 10_000,
 )
     fits = Dict{String,Any}()
     rows = NamedTuple[]
 
     for (name, spec) in specs
         solver_i = haskey(spec, :solver) ? spec.solver : default_solver
+        u0_i = haskey(spec, :u0) ? spec.u0 : u0
+        u0_builder_i = haskey(spec, :u0_builder) ? spec.u0_builder : nothing
         fit = run_joint_fit(
             spec.model,
             dataset_specs,
-            u0,
+            u0_i,
             spec.p0;
             solver = solver_i,
             bounds = get(spec, :bounds, nothing),
+            u0_builder = u0_builder_i,
             show_stats = show_stats,
+            maxiters = maxiters,
         )
         fits[name] = fit
         push!(rows, (Model = name, Params = fit.params, BIC = fit.bic, SSE = fit.sse))
@@ -1257,8 +1655,10 @@ function compare_joint_models_dict(
     )
 
     sort!(df_summary, :BIC)
-    CSV.write(output_csv, df_summary)
-    println("Joint comparison summary saved to $output_csv")
+    if output_csv !== nothing
+        CSV.write(output_csv, df_summary)
+        println("Joint comparison summary saved to $output_csv")
+    end
 
     return fits
 end

--- a/src/joint_summary.jl
+++ b/src/joint_summary.jl
@@ -1,0 +1,272 @@
+module JointSummary
+
+using DataFrames
+using Statistics
+
+export summarize_joint_bic, summarize_joint_bic_by_group, summarize_joint_parameter_stability,
+    summarize_pooling_bic, symmetric_relative_pair
+
+"""
+    symmetric_relative_pair(center, log_contrast)
+
+Return symmetric low/high environment values around a positive geometric center.
+For `abs(log_contrast) <= log(1.05)`, each value remains within five percent of
+the center.
+"""
+symmetric_relative_pair(center::Real, log_contrast::Real) = (
+    low = center * exp(-log_contrast),
+    high = center * exp(log_contrast),
+)
+
+"""
+    summarize_pooling_bic(df; group_col=:cell_line, top_n=5,
+        independent_mode="independent_diagnostic", inadequacy_delta=10.0)
+
+Rank eligible shared/partial-pooling candidates by BIC within each biological
+group. Independent fits are retained as diagnostics. A group is marked
+`inadequate_pooling` when its best independent fit improves BIC by at least
+`inadequacy_delta` over the best eligible fit.
+"""
+function summarize_pooling_bic(
+    df::AbstractDataFrame;
+    group_col::Symbol = :cell_line,
+    model_col::Symbol = :model,
+    pooling_col::Symbol = :pooling_mode,
+    bic_col::Symbol = :bic,
+    eligible_col::Symbol = :eligible_for_inheritance,
+    top_n::Int = 5,
+    independent_mode::AbstractString = "independent_diagnostic",
+    inadequacy_delta::Real = 10.0,
+)
+    top_n > 0 || throw(ArgumentError("top_n must be positive"))
+    _require_columns(df, [group_col, model_col, pooling_col, bic_col, eligible_col])
+    ranking_parts = DataFrame[]
+    status_rows = NamedTuple[]
+
+    for grp in groupby(DataFrame(df), group_col)
+        group_value = first(grp[!, group_col])
+        valid = grp[[value isa Real && isfinite(Float64(value)) && abs(Float64(value)) < 9.99e11 for value in grp[!, bic_col]], :]
+        eligible = valid[Bool.(valid[!, eligible_col]), :]
+        isempty(eligible) && continue
+        sort!(eligible, bic_col)
+        best_eligible_bic = Float64(first(eligible[!, bic_col]))
+        eligible.delta_bic = Float64.(eligible[!, bic_col]) .- best_eligible_bic
+        eligible.rank_within_cell_line = collect(1:nrow(eligible))
+        shown = first(eligible, min(top_n, nrow(eligible)))
+        push!(ranking_parts, shown)
+
+        independent = valid[String.(valid[!, pooling_col]) .== String(independent_mode), :]
+        best_independent_bic = isempty(independent) ? NaN : minimum(Float64.(independent[!, bic_col]))
+        improvement = isfinite(best_independent_bic) ? best_eligible_bic - best_independent_bic : NaN
+        inadequate = isfinite(improvement) && improvement >= inadequacy_delta
+        winner = first(eligible)
+        push!(status_rows, (
+            cell_line = string(group_value),
+            winning_model = string(winner[model_col]),
+            winning_pooling_mode = string(winner[pooling_col]),
+            winning_bic = best_eligible_bic,
+            best_independent_bic = best_independent_bic,
+            independent_bic_improvement = improvement,
+            inadequacy_delta = Float64(inadequacy_delta),
+            inadequate_pooling = inadequate,
+            inheritance_allowed = !inadequate,
+        ))
+    end
+
+    ranking = isempty(ranking_parts) ? DataFrame() : vcat(ranking_parts...; cols = :union)
+    !isempty(ranking) && sort!(ranking, [group_col, :rank_within_cell_line])
+    return (ranking = ranking, status = DataFrame(status_rows))
+end
+
+function _require_columns(df::AbstractDataFrame, columns)
+    available = Set(propertynames(df))
+    missing_columns = setdiff(Set(Symbol.(columns)), available)
+    isempty(missing_columns) || throw(ArgumentError("Missing required columns: $(sort!(collect(missing_columns)))"))
+end
+
+"""
+    summarize_joint_bic_by_group(df; group_col=:cell_line, top_n=5,
+                                 model_col=:model, bic_col=:bic,
+                                 environment_cols=[:density])
+
+Rank models separately within a biological grouping such as cell line while
+aggregating BIC across that group's independently fitted environments. The
+returned table contains at most `top_n` complete model summaries per group.
+"""
+function summarize_joint_bic_by_group(
+    df::AbstractDataFrame;
+    group_col::Symbol = :cell_line,
+    top_n::Int = 5,
+    model_col::Symbol = :model,
+    bic_col::Symbol = :bic,
+    environment_cols::Vector{Symbol} = [:density],
+)
+    top_n > 0 || throw(ArgumentError("top_n must be positive"))
+    _require_columns(df, [group_col, model_col, bic_col, environment_cols...])
+    summaries = DataFrame[]
+    rank_col = Symbol("rank_within_", String(group_col))
+
+    for grp in groupby(DataFrame(df), group_col)
+        group_value = first(grp[!, group_col])
+        summary = summarize_joint_bic(
+            grp;
+            model_col = model_col,
+            bic_col = bic_col,
+            environment_cols = environment_cols,
+        ).aggregate
+        isempty(summary) && continue
+        complete = summary[summary.complete_environment_coverage, :]
+        candidates = isempty(complete) ? summary : complete
+        shown = first(candidates, min(top_n, nrow(candidates)))
+        insertcols!(shown, 1, group_col => fill(group_value, nrow(shown)))
+        insertcols!(shown, 2, rank_col => collect(1:nrow(shown)))
+        push!(summaries, shown)
+    end
+
+    isempty(summaries) && return DataFrame()
+    result = vcat(summaries...; cols = :union)
+    sort!(result, [group_col, rank_col])
+    return result
+end
+
+"""
+    summarize_joint_bic(df; model_col=:model, bic_col=:bic,
+                        environment_cols=[:cell_line, :density])
+
+Summarize model BIC values across independently fitted environments. Returns
+`(long, matrix, aggregate, winners)`. `aggregate.total_bic` is the sum across
+complete environments, and `delta_total_bic` is measured from the best total.
+"""
+function summarize_joint_bic(
+    df::AbstractDataFrame;
+    model_col::Symbol = :model,
+    bic_col::Symbol = :bic,
+    environment_cols::Vector{Symbol} = [:cell_line, :density],
+)
+    _require_columns(df, [model_col, bic_col, environment_cols...])
+    rows = NamedTuple[]
+    winner_rows = NamedTuple[]
+
+    for grp in groupby(DataFrame(df), environment_cols)
+        environment = join([string(first(grp[!, col])) for col in environment_cols], " | ")
+        valid = grp[[value isa Real && isfinite(Float64(value)) && abs(Float64(value)) < 9.99e11 for value in grp[!, bic_col]], :]
+        isempty(valid) && continue
+        ordered = sort(DataFrame(valid), bic_col)
+        best_bic = Float64(first(ordered[!, bic_col]))
+        for (rank, row) in enumerate(eachrow(ordered))
+            push!(rows, (
+                model = string(row[model_col]),
+                environment = environment,
+                bic = Float64(row[bic_col]),
+                delta_bic = Float64(row[bic_col]) - best_bic,
+                environment_rank = rank,
+            ))
+        end
+        winner = first(ordered)
+        push!(winner_rows, (
+            environment = environment,
+            winning_model = string(winner[model_col]),
+            winning_bic = Float64(winner[bic_col]),
+        ))
+    end
+
+    long = DataFrame(rows)
+    isempty(long) && return (long = long, matrix = DataFrame(), aggregate = DataFrame(), winners = DataFrame(winner_rows))
+    n_environments = length(unique(long.environment))
+    aggregate_rows = NamedTuple[]
+    for grp in groupby(long, :model)
+        bics = Float64.(grp.bic)
+        deltas = Float64.(grp.delta_bic)
+        ranks = Float64.(grp.environment_rank)
+        push!(aggregate_rows, (
+            model = first(grp.model),
+            environments_fit = nrow(grp),
+            complete_environment_coverage = nrow(grp) == n_environments,
+            total_bic = sum(bics),
+            mean_bic = mean(bics),
+            mean_environment_rank = mean(ranks),
+            environment_wins = count(==(1.0), ranks),
+            sum_environment_delta_bic = sum(deltas),
+            worst_environment_delta_bic = maximum(deltas),
+        ))
+    end
+
+    aggregate = DataFrame(aggregate_rows)
+    complete_totals = aggregate.total_bic[aggregate.complete_environment_coverage]
+    best_total = isempty(complete_totals) ? minimum(aggregate.total_bic) : minimum(complete_totals)
+    aggregate.delta_total_bic = aggregate.total_bic .- best_total
+    aggregate.relative_support = [
+        delta <= 2 ? "substantial" :
+        delta <= 6 ? "moderate" :
+        delta <= 10 ? "weak" : "little"
+        for delta in aggregate.delta_total_bic
+    ]
+    sort!(aggregate, [:delta_total_bic, :mean_environment_rank])
+
+    matrix = unstack(select(long, :model, :environment, :bic), :model, :environment, :bic)
+    matrix = leftjoin(select(aggregate, :model, :total_bic, :delta_total_bic, :mean_environment_rank, :environment_wins, :relative_support), matrix; on = :model)
+    sort!(matrix, :delta_total_bic)
+    winners = sort(DataFrame(winner_rows), :environment)
+    return (long = long, matrix = matrix, aggregate = aggregate, winners = winners)
+end
+
+"""
+    summarize_joint_parameter_stability(parameter_df)
+
+Summarize independently fitted parameter values across environments. The input
+must contain `model`, `parameter`, `value`, `lower_bound`, and `upper_bound`.
+`bound_range_fraction` reports the observed cross-environment span as a
+fraction of the allowed optimization interval.
+"""
+function summarize_joint_parameter_stability(
+    parameter_df::AbstractDataFrame;
+    model_col::Symbol = :model,
+    parameter_col::Symbol = :parameter,
+    value_col::Symbol = :value,
+    lower_col::Symbol = :lower_bound,
+    upper_col::Symbol = :upper_bound,
+)
+    _require_columns(parameter_df, [model_col, parameter_col, value_col, lower_col, upper_col])
+    rows = NamedTuple[]
+
+    for grp in groupby(DataFrame(parameter_df), [model_col, parameter_col])
+        values = Float64.(grp[!, value_col])
+        lower = minimum(Float64.(grp[!, lower_col]))
+        upper = maximum(Float64.(grp[!, upper_col]))
+        allowed_span = upper - lower
+        value_min = minimum(values)
+        value_max = maximum(values)
+        value_mean = mean(values)
+        value_sd = length(values) > 1 ? std(values) : 0.0
+        observed_span = value_max - value_min
+        bound_fraction = allowed_span > 0 ? observed_span / allowed_span : NaN
+        boundary_margin = allowed_span > 0 ? min(value_min - lower, upper - value_max) / allowed_span : NaN
+        coefficient_of_variation = abs(value_mean) > 1e-12 ? value_sd / abs(value_mean) : NaN
+        stability_class = !isfinite(bound_fraction) ? "not_assessed" :
+            bound_fraction <= 0.10 ? "tight" :
+            bound_fraction <= 0.25 ? "moderate" : "broad"
+        push!(rows, (
+            model = string(first(grp[!, model_col])),
+            parameter = string(first(grp[!, parameter_col])),
+            environments_fit = length(values),
+            value_mean = value_mean,
+            value_sd = value_sd,
+            value_min = value_min,
+            value_max = value_max,
+            observed_span = observed_span,
+            coefficient_of_variation = coefficient_of_variation,
+            lower_bound = lower,
+            upper_bound = upper,
+            bound_range_fraction = bound_fraction,
+            minimum_boundary_margin_fraction = boundary_margin,
+            near_optimization_bound = isfinite(boundary_margin) && boundary_margin < 0.05,
+            stability_class = stability_class,
+        ))
+    end
+
+    result = DataFrame(rows)
+    !isempty(result) && sort!(result, [:model, :parameter])
+    return result
+end
+
+end

--- a/test/joint_summary_test.jl
+++ b/test/joint_summary_test.jl
@@ -1,0 +1,45 @@
+using Test
+using DataFrames
+using GrowthParameterEstimation
+
+@testset "Joint comparison summaries" begin
+    joint = DataFrame(
+        model = repeat(["A", "B"], 2),
+        cell_line = repeat(["naive", "resistant"], inner = 2),
+        density = fill("20k", 4),
+        bic = [10.0, 13.0, 20.0, 19.0],
+    )
+    summary = summarize_joint_bic(joint)
+    @test nrow(summary.aggregate) == 2
+    @test summary.aggregate.model[1] == "A"
+    @test summary.aggregate.total_bic[1] == 30.0
+    @test summary.aggregate.delta_total_bic[1] == 0.0
+    @test nrow(summary.winners) == 2
+
+    parameters = DataFrame(
+        model = ["A", "A", "A", "A"],
+        parameter = ["kill", "kill", "delay", "delay"],
+        value = [0.20, 0.22, 1.0, 4.0],
+        lower_bound = [0.0, 0.0, 0.0, 0.0],
+        upper_bound = [1.0, 1.0, 5.0, 5.0],
+    )
+    stability = summarize_joint_parameter_stability(parameters)
+    kill = only(filter(row -> row.parameter == "kill", stability))
+    delay = only(filter(row -> row.parameter == "delay", stability))
+    @test kill.stability_class == "tight"
+    @test delay.stability_class == "broad"
+    @test isapprox(kill.bound_range_fraction, 0.02)
+
+    grouped = DataFrame(
+        model = repeat(["A", "B", "C"], 4),
+        cell_line = repeat(["naive", "naive", "cis", "cis"], inner = 3),
+        density = repeat(["20k", "30k", "20k", "30k"], inner = 3),
+        bic = [10.0, 12.0, 18.0, 11.0, 15.0, 19.0, 14.0, 13.0, 20.0, 16.0, 15.0, 21.0],
+    )
+    top_by_cell = summarize_joint_bic_by_group(grouped; top_n = 2)
+    @test nrow(top_by_cell) == 4
+    @test all(combine(groupby(top_by_cell, :cell_line), nrow => :count).count .== 2)
+    @test top_by_cell.model[top_by_cell.cell_line .== "naive"] == ["A", "B"]
+    @test top_by_cell.model[top_by_cell.cell_line .== "cis"] == ["B", "A"]
+    @test all(first(group).delta_total_bic == 0.0 for group in groupby(top_by_cell, :cell_line))
+end

--- a/test/pooling_profile_test.jl
+++ b/test/pooling_profile_test.jl
@@ -1,0 +1,70 @@
+@testset "Pooling summaries and boundary profiles" begin
+    pair = symmetric_relative_pair(10.0, log(1.05))
+    @test isapprox(pair.low, 10 / 1.05)
+    @test isapprox(pair.high, 10 * 1.05)
+
+    pooling = DataFrame(
+        cell_line = ["A", "A", "A", "B", "B", "B"],
+        model = ["m", "m", "m", "m", "m", "m"],
+        pooling_mode = ["shared", "partial_5pct", "independent_diagnostic", "shared", "partial_5pct", "independent_diagnostic"],
+        bic = [100.0, 101.0, 95.0, 120.0, 118.0, 105.0],
+        eligible_for_inheritance = [true, true, false, true, true, false],
+    )
+    summary = summarize_pooling_bic(pooling; top_n = 2)
+    @test nrow(summary.ranking) == 4
+    @test !summary.status[summary.status.cell_line .== "A", :inadequate_pooling][1]
+    @test summary.status[summary.status.cell_line .== "B", :inadequate_pooling][1]
+
+    function pooled_logistic!(du, u, p, t)
+        r, K = p
+        for i in eachindex(u)
+            du[i] = r * u[i] * (1 - u[i] / K)
+        end
+    end
+    times = collect(0.0:1.0:8.0)
+    truth = [0.3, 25.0]
+    initial = [1.0, 2.0]
+    problem = ODEProblem(pooled_logistic!, initial, (first(times), last(times)), truth)
+    solution = solve(problem, Tsit5(); saveat = times)
+    datasets = [
+        (x = times, y = [u[1] for u in solution.u], state_index = 1, residual_scale = 10.0),
+        (x = times, y = [u[2] for u in solution.u], state_index = 2, residual_scale = 15.0),
+    ]
+    profiled = profile_joint_fit_bounds(
+        pooled_logistic!, datasets, initial, [0.15, 20.0];
+        bounds = [(0.01, 0.2), (5.0, 60.0)],
+        parameter_names = [:r, :K],
+        explicit_upper_profiles = Dict(:r => [0.3, 0.4]),
+        optimizer = :nelder_mead,
+        maxiters = 1200,
+        show_stats = false,
+    )
+    @test isfinite(profiled.fit.bic)
+    @test any(profiled.profile.accepted)
+    @test profiled.bounds[1][2] > 0.2
+    @test all(in.(
+        profiled.identifiability.identifiability,
+        Ref(["interior", "poorly_identified_at_bound"]),
+    ))
+
+    function lower_profile_model!(du, u, p, t)
+        du[1] = p[1] * u[1]
+    end
+    lower_truth = [-0.5]
+    lower_problem = ODEProblem(lower_profile_model!, [5.0], (0.0, 5.0), lower_truth)
+    lower_solution = solve(lower_problem, Tsit5(); saveat = 0.0:1.0:5.0)
+    lower_datasets = [(x = collect(0.0:1.0:5.0), y = [state[1] for state in lower_solution.u], state_index = 1, residual_scale = 5.0)]
+    lower_profiled = profile_joint_fit_bounds_two_sided(
+        lower_profile_model!, lower_datasets, [5.0], [-0.1];
+        bounds = [(-0.2, 0.5)],
+        parameter_names = [:beta],
+        explicit_lower_profiles = Dict(:beta => [-0.6, -1.0]),
+        physical_lower_limits = Dict(:beta => -1.0),
+        optimizer = :nelder_mead,
+        maxiters = 800,
+        show_stats = false,
+    )
+    @test isfinite(lower_profiled.fit.bic)
+    @test any((lower_profiled.profile.direction .== "lower") .& lower_profiled.profile.accepted)
+    @test lower_profiled.bounds[1][1] < -0.2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -580,7 +580,7 @@ using Random
         @test length(joint_fit.params) == 2
         @test isfinite(joint_fit.bic)
         @test joint_fit.sse >= 0
-        @test joint_fit.raw_sse == joint_fit.sse
+        @test isapprox(joint_fit.raw_sse, joint_fit.sse)
 
         delayed_times = collect(1.0:1.0:5.0)
         delayed_prob = ODEProblem(logistic_joint!, u0_joint, (0.0, delayed_times[end]), p_true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,25 +71,25 @@ using Random
         GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.build_logistic())(du, [2.0], [0.2, 10.0], 0.0)
         @test isfinite(du[1])
 
-        logistic_growth_with_death!(du, [2.0], [0.2, 10.0, 0.01], 0.0)
+        GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.LogisticWithDeathModel(0.2, 10.0, 0.01))(du, [2.0], [0.2, 10.0, 0.01], 0.0)
         @test isfinite(du[1])
 
         GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.build_gompertz())(du, [2.0], [0.2, 1.0, 10.0], 0.0)
         @test isfinite(du[1])
 
-        gompertz_growth_with_death!(du, [2.0], [0.2, 1.0, 10.0, 0.01], 0.0)
+        GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.GompertzWithDeathModel(0.2, 1.0, 10.0, 0.01))(du, [2.0], [0.2, 1.0, 10.0, 0.01], 0.0)
         @test isfinite(du[1])
 
         GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.build_exponential())(du, [2.0], [0.2], 0.0)
         @test isfinite(du[1])
 
-        exponential_growth_with_delay!(du, [2.0], [0.2, 10.0, 1.0], 2.0)
+        GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.ExponentialWithDelayModel(0.2, 10.0, 1.0))(du, [2.0], [0.2, 10.0, 1.0], 2.0)
         @test isfinite(du[1])
 
-        logistic_growth_with_delay!(du, [2.0], [0.2, 10.0, 1.0], 2.0)
+        GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.LogisticWithDelayModel(0.2, 10.0, 1.0))(du, [2.0], [0.2, 10.0, 1.0], 2.0)
         @test isfinite(du[1])
 
-        exponential_growth_with_death_and_delay!(du, [2.0], [0.2, 10.0, 0.01, 1.0], 2.0)
+        GrowthParameterEstimation.Models.to_ode!(GrowthParameterEstimation.Models.ExponentialWithDeathAndDelayModel(0.2, 10.0, 0.01, 1.0))(du, [2.0], [0.2, 10.0, 0.01, 1.0], 2.0)
         @test isfinite(du[1])
     end
 
@@ -265,7 +265,7 @@ using Random
         @test validate_strict_schema(strict_df)
 
         strict_bad = select(strict_df, Not(:culture_type))
-        @test_throws ErrorException validate_strict_schema(strict_bad)
+        @test_throws ErrorException validate_strict_schema(strict_bad; required_metadata = vcat(GrowthParameterEstimation.DataLayer.STRICT_REQUIRED_METADATA, [:culture_type]))
 
         qc = generate_qc_report(strict_df)
         @test all(col -> col in Symbol.(names(qc.missingness)), [:column, :n_missing, :frac_missing])
@@ -580,11 +580,90 @@ using Random
         @test length(joint_fit.params) == 2
         @test isfinite(joint_fit.bic)
         @test joint_fit.sse >= 0
+        @test joint_fit.raw_sse == joint_fit.sse
+
+        delayed_times = collect(1.0:1.0:5.0)
+        delayed_prob = ODEProblem(logistic_joint!, u0_joint, (0.0, delayed_times[end]), p_true)
+        delayed_sol = solve(delayed_prob, Tsit5(); saveat = delayed_times)
+        delayed_data = [
+            (x = delayed_times, y = [u[1] for u in delayed_sol.u], state_index = 1),
+            (x = delayed_times, y = [u[2] for u in delayed_sol.u], state_index = 2),
+        ]
+        delayed_fit = run_joint_fit(
+            logistic_joint!, delayed_data, u0_joint, [0.2, 20.0];
+            bounds = [(0.01, 1.0), (5.0, 60.0)],
+            initial_time = 0.0,
+            show_stats = false,
+        )
+        @test delayed_fit.initial_time == 0.0
+        @test first(delayed_fit.save_times) == 1.0
+        @test all(length(prediction) == length(delayed_times) for prediction in delayed_fit.predictions)
+        @test_throws ArgumentError run_joint_fit(
+            logistic_joint!, delayed_data, u0_joint, [0.2, 20.0];
+            bounds = [(0.01, 1.0), (5.0, 60.0)],
+            initial_time = 2.0,
+            show_stats = false,
+        )
+
+        scaled_datasets = [merge(ds, (residual_scale = maximum(ds.y),)) for ds in datasets]
+        scaled_joint_fit = run_joint_fit(
+            logistic_joint!, scaled_datasets, u0_joint, [0.2, 20.0];
+            bounds = [(0.01, 1.0), (5.0, 60.0)],
+            show_stats = false,
+        )
+        @test isfinite(scaled_joint_fit.bic)
+        @test scaled_joint_fit.scaled_sse == scaled_joint_fit.sse
+        @test isfinite(scaled_joint_fit.raw_sse)
+        @test scaled_joint_fit.raw_sse >= scaled_joint_fit.scaled_sse
+
+        function split_joint!(du, u, p, t)
+            decay_live, decay_damaged, _ = p
+            du[1] = -decay_live * u[1]
+            du[2] = decay_live * u[1] - decay_damaged * u[2]
+        end
+        split_times = collect(0.0:1.0:4.0)
+        split_true = [0.4, 0.2, 0.75]
+        split_u0_builder(p) = [10.0 * p[3], 10.0 * (1 - p[3])]
+        split_prob = ODEProblem(split_joint!, split_u0_builder(split_true), (0.0, 4.0), split_true)
+        split_sol = solve(split_prob, Tsit5(); saveat = split_times)
+        split_y = [u[1] + 0.5 * u[2] for u in split_sol.u]
+        split_data = [(
+            x = split_times,
+            y = split_y,
+            observable = (u, p, t) -> u[1] + 0.5 * u[2],
+        )]
+        split_fit = run_joint_fit(
+            split_joint!, split_data, [7.0, 3.0], [0.3, 0.3, 0.6];
+            bounds = [(0.01, 1.0), (0.01, 1.0), (0.01, 0.99)],
+            u0_builder = split_u0_builder,
+            show_stats = false,
+        )
+        @test length(split_fit.params) == 3
+        @test isfinite(split_fit.bic)
+        @test all(isfinite, only(split_fit.predictions))
 
         specs = Dict(
             "LogisticJoint" => (model = logistic_joint!, p0 = [0.2, 20.0], bounds = [(0.01, 1.0), (5.0, 60.0)]),
         )
         joint_models = compare_joint_models_dict(datasets, u0_joint, specs; default_solver = Tsit5(), show_stats = false, output_csv = joinpath(tempdir(), "joint_compare_smoke.csv"))
         @test haskey(joint_models, "LogisticJoint")
+
+        multistart = run_joint_multistart(
+            logistic_joint!,
+            scaled_datasets,
+            u0_joint,
+            [[0.08, 12.0], [0.3, 30.0]];
+            bounds = [(0.01, 1.0), (5.0, 60.0)],
+            optimizer = :nelder_mead,
+            maxiters = 800,
+            show_stats = false,
+        )
+        @test isfinite(multistart.fit.bic)
+        @test nrow(multistart.summary) == 2
+        @test multistart.best_start_index in 1:2
+        @test all(multistart.summary.status .== "completed")
     end
 end
+
+include("joint_summary_test.jl")
+include("pooling_profile_test.jl")


### PR DESCRIPTION
## Summary

- Reconciles reusable downstream joint fitting functionality into the canonical package for the v0.4 release line.
- Bumps the package to `v0.4.1` for Julia General Registry registration readiness after superseding the unregistered `v0.4.0` GitHub release.
- Adds generalized `run_joint_fit` support for fixed initial times, `u0_builder`, observable callbacks, trajectory residual scaling, raw/scaled SSE, finite-fit rejection, bounded Nelder-Mead screening, multistart fitting, and one/two-sided bound profiling.
- Adds reusable joint BIC, pooling BIC, and parameter stability summaries while leaving A2780-specific equations, staging, plotting, metadata decoding, and report rendering downstream.
- Adds registry-compatible compat bounds for standard-library dependencies and focused tests/docs/changelog updates.

Closes #40.

## Breaking Updates

- Breaking: this is a pre-1.0 minor release line, so `v0.4.x` is treated as a breaking update relative to `v0.3.x` for Julia package registration and downstream compatibility expectations.
- Breaking: joint fitting now rejects failed, non-finite, negative-prediction, and failure-sentinel fits consistently during optimization and multistart ranking. Downstream validation scripts that asserted legacy finite-fit counts may need scientific review of the new ranked model set.
- Breaking: joint BIC summaries now count optimized joint parameters directly and exclude fixed initial-time seeding states and observations absent from `dataset_specs`, which can change model ranking summaries compared with earlier downstream helper implementations.

## Validation

- Package test file passed on Julia `1.10.4`: main testset `134/134`, joint summaries `13/13`, pooling/profile `12/12`.
- Earlier downstream CancerGrowthDynamics validation against this package worktree:
  - `validate_a2780_module_load.jl`: passed
  - `validate_density_pooling.jl`: passed
  - `validate_a2780_staged_setup.jl`: passed
  - `validate_a2780_timing_linked.jl`: passed (`87/87`)
  - `execute_a2780_notebook.jl`: passed
  - `refresh_a2780_report_only.jl`: passed
- `validate_a2780_coculture_joint.jl` is blocked by a scientific validation mismatch: linked-treatment ranking now contains 9 finite models, while the validation asserts exactly 5. The new rank-1 model is `load_plus_tolerant_growth_context`; the original core models are still present. This needs scientific approval before broadening that downstream assertion.

## Registry Notes

- `Project.toml` is now `version = 0.4.1`.
- `CHANGELOG.md` includes explicit breaking-change notes for the v0.4 line.
- Julia General Registry submission should use `@JuliaRegistrator register` from `main` after merge.